### PR TITLE
Use custom config to replace config.freeform

### DIFF
--- a/boringdroid_x86_64.mk
+++ b/boringdroid_x86_64.mk
@@ -31,7 +31,7 @@ PRODUCT_ENFORCE_ARTIFACT_PATH_REQUIREMENTS := relaxed
 endif
 # region @boringdroid
 PRODUCT_COPY_FILES += \
-    device/generic/goldfish/data/etc/config.ini.freeform:config.ini \
+    device/generic/boringdroid_x86_64/data/etc/config.ini.boringdroid:config.ini \
 # endregion
 
 #

--- a/data/etc/config.ini.boringdroid
+++ b/data/etc/config.ini.boringdroid
@@ -1,0 +1,22 @@
+avd.ini.encoding=UTF-8
+disk.dataPartition.size=6G
+fastboot.forceColdBoot = yes
+hw.accelerometer=yes
+hw.audioInput=yes
+hw.battery=yes
+hw.camera.back=emulated
+hw.camera.front=emulated
+hw.dPad=no
+hw.gps=yes
+hw.gpu.enabled=yes
+hw.keyboard=yes
+hw.lcd.density=240
+hw.mainKeys=no
+hw.ramSize=4096
+hw.sensors.orientation=yes
+hw.sensors.proximity=yes
+image.sysdir.1=x86/
+skin.dynamic=no
+skin.name=3000x2000
+skin.path=3000x2000
+


### PR DESCRIPTION
Some variants, such as BlissOS, don't use freeform config. And
boringdroid should process pc mode for normal display config.

resolves BOR-50